### PR TITLE
Make fully functional and add option to disable ability to disable notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,15 @@ NotifyWho can be configured at the blog level by visiting Tools > Plugins > Noti
 
 Notifications can be sent when an entry is created, and when an entry is published. These are both options specifically for blogs that are set to *not* publish by default, where being notified that an entry has been created could be useful.
 
-# Public Submissions
+# Public submissions
 
 If you're making use of the Community.Pack's public submission form capability, it is likely useful to receive an email when the new entry is created or published. NotifyWho can work with the public submission form with a simple addition to the form:
 
     <input type="hidden" name="auto_notifications" value="1" />
+
+# Known issues
+
+NotifyWho uses Movable Type’s built in `send_notify` function, which always sends a notification to the entry author in addition to any other recipients. It is therefore not currently possible to exclude the author from the recipients list. If you want to *only* notify the author, though, the plugin must explicitly send a notifcation to the author, but this results in two e-mails being sent to the author since the `send_notify` always sends an e-mail to the author in addition to the given recipients. If you are sending notifications to anyone aside from the author, then you can uncheck the “Author” option in the plugin settings, since the author will be notified anyway. This will avoid duplicate e-mails being sent to the author.
 
 # Copyright
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ entry, comment and TrackBack notifications for each blog.
 
 You can configure the plugin to send them to:
 
-   * The Entry author (MT default)
+   * The Entry author (Movable Type default)
    * One or more arbitrary email addresses
-   * The blog's address book (i.e. notification list)
+   * The blog’s [address book](https://movabletype.org/documentation/appendices/config-directives/enableaddressbook.html) (i.e. notification list)
    * Any of the above
 
 For entry notifications, you can configure the plugin to send them
@@ -17,7 +17,7 @@ link directly about the entry save/preview buttons.
 
 # Requirements
 
-* Movable Type 4.x or 5.x
+* Movable Type 4+
 * A working email notification system
 * Ability to install plugins
 * Permission to configure a blog and its plugins

--- a/README.md
+++ b/README.md
@@ -3,12 +3,16 @@
 The NotifyWho?! plugin enables you to control exactly who should receive
 entry, comment and TrackBack notifications for each blog.
 
-You can configure the plugin to send them to:
+You can configure the plugin to send any combination of:
 
-   * The Entry author (Movable Type default)
-   * One or more arbitrary email addresses
-   * The blog’s [address book](https://movabletype.org/documentation/appendices/config-directives/enableaddressbook.html) (i.e. notification list)
-   * Any of the above
+   * Entry creation and publication notifications:
+       * Author (useful when entries added on behalf of author, such as via [Ghostwriter](https://plugins.movabletype.org/ghostwriter/))
+       * Arbitrary email addresses
+       * The blog’s [address book](https://movabletype.org/documentation/appendices/config-directives/enableaddressbook.html) (i.e. notification list)
+   * Feedback notifications:
+       * Author (Movable Type default)
+       * Arbitrary email addresses
+       * The blog’s [address book](https://movabletype.org/documentation/appendices/config-directives/enableaddressbook.html)
 
 For entry notifications, you can configure the plugin to send them
 automatically or to simply provide defaults for the Share entry screen.

--- a/plugins/NotifyWho/lib/NotifyWho.pm
+++ b/plugins/NotifyWho/lib/NotifyWho.pm
@@ -337,9 +337,16 @@ sub _automatic_notifications {
     my $auto = $plugin->get_config_value('nw_entry_auto', $blogarg) || 0;
     return unless $auto || $param->{status} != 1;
 
+    my $hiddeninput = '<input type="hidden" name="auto_notifications" id="auto_notifications" value="1" />';
     my $node = $tmpl->createTextNode(<<EOM);
-        <p>Automatic notifications for this entry are: <a href="javascript:void(0)" onclick="toggle_notifications(); return false;" id="auto_notifications_link">Enabled</a><input type="hidden" name="auto_notifications" id="auto_notifications" value="$auto" /></p>
+        <p>Automatic notifications for this entry are: <a href="javascript:void(0)" onclick="toggle_notifications(); return false;" id="auto_notifications_link">Enabled</a>$hiddeninput</p>
 EOM
+
+    # if forced option set, hide the toggle by overwriting node
+    # but keep the hidden form input to keep notifications working,
+    my $force = $plugin->get_config_value('nw_entry_force', $blogarg) || 0;
+    $node = $tmpl->createTextNode($hiddeninput) if ($force);
+
     $tmpl->insertAfter($node, $tmpl->getElementById('keywords'));
 }
 

--- a/plugins/NotifyWho/lib/NotifyWho.pm
+++ b/plugins/NotifyWho/lib/NotifyWho.pm
@@ -197,7 +197,7 @@ sub autosend_entry_notify {
         return;
     }
     elsif ( ! _is_new_entry($notify_upon_create, $entry, $orig_obj) ) {
-        ###l4p $logger->debug('NOT A NEW ENTRY - Aborting send notify');
+        ###l4p $logger->debug('NOT A NEW ENTRY OR NOTIFY ON CREATE TURNED OFF - Aborting send notify');
         return;
     }
 
@@ -305,20 +305,9 @@ sub _automatic_notifications {
 
     my $blogarg = 'blog:'.$app->blog->id;
 
-    # Is this a bug?
-    # As this is written, notify upon entry creation *and* notify upon entry
-    # publication must be true. But, either one should be enough for
-    # notification, right?
-
-    # Notify upon entry creation?
-    my $auto
-       = $plugin->get_config_value('nw_entry_created_auto', $blogarg) || 0;
-    return unless $auto;
-
-    # Or notify upon entry publication?
-    $auto
-       = $plugin->get_config_value('nw_entry_auto', $blogarg) || 0;
-    return unless $auto;
+    # hide the toggle (thereby disabling notifications) on draft entries unless "on publish" enabled
+    my $auto = $plugin->get_config_value('nw_entry_auto', $blogarg) || 0;
+    return unless $auto || $param->{status} != 1;
 
     my $node = $tmpl->createTextNode(<<EOM);
         <p>Automatic notifications for this entry are: <a href="javascript:void(0)" onclick="toggle_notifications(); return false;" id="auto_notifications_link">Enabled</a><input type="hidden" name="auto_notifications" id="auto_notifications" value="$auto" /></p>

--- a/plugins/NotifyWho/lib/NotifyWho.pm
+++ b/plugins/NotifyWho/lib/NotifyWho.pm
@@ -495,11 +495,19 @@ sub _is_new_entry {
     my ($notify_upon_create, $entry, $orig_obj) = @_;
 
     return (
-            ($notify_upon_create && (!$orig_obj || !$orig_obj->id)) # Notify of new entry
+        # Notify of new entry
+        ($notify_upon_create && (!$orig_obj || !$orig_obj->id))
         ||
-            ($entry->status == MT::Entry::RELEASE)      # Is now published
-        && ((!$orig_obj || !$orig_obj->id)              # Is a new entry
-            || $orig_obj->status != MT::Entry::RELEASE) # Was not published
+            # Is now published or scheduled
+            ($entry->status == MT::Entry::RELEASE || $entry->status == MT::Entry::FUTURE)
+            &&
+            (
+                # Is new entry
+                (!$orig_obj || !$orig_obj->id)
+                ||
+                # Was not published or scheduled
+                $orig_obj->status != MT::Entry::RELEASE && $orig_obj->status != MT::Entry::FUTURE
+            )
         || 0
     );
 }

--- a/plugins/NotifyWho/lib/NotifyWho.pm
+++ b/plugins/NotifyWho/lib/NotifyWho.pm
@@ -300,7 +300,8 @@ sub _automatic_notifications {
     my ($cb, $app, $param, $tmpl) = @{$_[0]};
     ###l4p $logger ||= MT::Log::Log4perl->new(); $logger->trace();
 
-    return unless $param->{new_object};
+    # hide the toggle (thereby disabling notifications) on published or scheduled entries
+    return if $param->{status} == 2 || $param->{status} == 4;
 
     my $blogarg = 'blog:'.$app->blog->id;
 

--- a/plugins/NotifyWho/lib/NotifyWho.pm
+++ b/plugins/NotifyWho/lib/NotifyWho.pm
@@ -495,10 +495,10 @@ sub _is_new_entry {
     my ($notify_upon_create, $entry, $orig_obj) = @_;
 
     return (
-            ($notify_upon_create && !$orig_obj)         # Notify of new entry
+            ($notify_upon_create && (!$orig_obj || !$orig_obj->id)) # Notify of new entry
         ||
             ($entry->status == MT::Entry::RELEASE)      # Is now published
-        && (! $orig_obj                                 # Is a new entry
+        && ((!$orig_obj || !$orig_obj->id)              # Is a new entry
             || $orig_obj->status != MT::Entry::RELEASE) # Was not published
         || 0
     );

--- a/plugins/NotifyWho/notifywho.pl
+++ b/plugins/NotifyWho/notifywho.pl
@@ -15,7 +15,7 @@ use MT::Mail;
 use NotifyWho::Notification;
 
 # Public version number
-our $VERSION = "2.1.0";
+our $VERSION = "2.1.1";
 
 # Development revision number
 #our $Revision = ('$Revision: 504 $ ' =~ /(\d+)/);

--- a/plugins/NotifyWho/notifywho.pl
+++ b/plugins/NotifyWho/notifywho.pl
@@ -40,6 +40,7 @@ MT->add_plugin($plugin = __PACKAGE__->new({
         ['nw_entry_force',          { Default => 0 }], # disallow user from disabling
         ['nw_entry_auto',           { Default => 0 }], # entry publication
         ['nw_entry_created_auto',   { Default => 0 }], # entry creation
+        ['nw_entry_author',         { Default => 0 }],
         ['nw_entry_list',           { Default => 0 }],
         ['nw_entry_emails',         { Default => '' }],
         ['nw_entry_message',        { Default => '' }],

--- a/plugins/NotifyWho/notifywho.pl
+++ b/plugins/NotifyWho/notifywho.pl
@@ -69,6 +69,11 @@ sub init_registry {
         callbacks => {
 
             # If enabled, this callback handles the sending of notifications
+            # after an entry is published by Batch Edit or Manage Entries screen.
+            'cms_post_bulk_save.entries'
+                            => sub { runner('autosend_entry_notify_bulk', @_) },
+
+            # If enabled, this callback handles the sending of notifications
             # after an entry is newly published.
             'cms_post_save.entry'
                             => sub { runner('autosend_entry_notify', @_) },

--- a/plugins/NotifyWho/notifywho.pl
+++ b/plugins/NotifyWho/notifywho.pl
@@ -15,7 +15,7 @@ use MT::Mail;
 use NotifyWho::Notification;
 
 # Public version number
-our $VERSION = "2.0.5";
+our $VERSION = "2.1.0";
 
 # Development revision number
 #our $Revision = ('$Revision: 504 $ ' =~ /(\d+)/);

--- a/plugins/NotifyWho/notifywho.pl
+++ b/plugins/NotifyWho/notifywho.pl
@@ -15,7 +15,7 @@ use MT::Mail;
 use NotifyWho::Notification;
 
 # Public version number
-our $VERSION = "2.1.1";
+our $VERSION = "2.1.2";
 
 # Development revision number
 #our $Revision = ('$Revision: 504 $ ' =~ /(\d+)/);

--- a/plugins/NotifyWho/notifywho.pl
+++ b/plugins/NotifyWho/notifywho.pl
@@ -37,6 +37,7 @@ MT->add_plugin($plugin = __PACKAGE__->new({
         ['nw_fback_author',         { Default => 1 }],
         ['nw_fback_emails',         { Default => '' }],
         ['nw_fback_list',           { Default => 0 }],
+        ['nw_entry_force',          { Default => 0 }], # disallow user from disabling
         ['nw_entry_auto',           { Default => 0 }], # entry publication
         ['nw_entry_created_auto',   { Default => 0 }], # entry creation
         ['nw_entry_list',           { Default => 0 }],

--- a/plugins/NotifyWho/tmpl/blog_config.tmpl
+++ b/plugins/NotifyWho/tmpl/blog_config.tmpl
@@ -21,7 +21,7 @@
 
         <p>
             <input type="checkbox" name="nw_entry_author" id="nw_entry_author" value="1" <mt:if name="nw_entry_author">checked="checked"</mt:if> />
-            <label for="nw_entry_author">Author<!-- (Add to “other e-mail addresses” list.) --></label>
+            <label for="nw_entry_author">Always notify author (if unchecked, author will still be notified if anyone else is notified.)<!-- (Add to “other e-mail addresses” list.) --></label>
         </p>
 
         <p>

--- a/plugins/NotifyWho/tmpl/blog_config.tmpl
+++ b/plugins/NotifyWho/tmpl/blog_config.tmpl
@@ -57,16 +57,16 @@
     <mtapp:setting
         id="nw_entry_auto_setting"
         label="<__trans phrase="Automatic notification">"
-        hint="<__trans phrase="If checked, automatic delivery can be overridden on a per-entry basis.">"
+        hint="<__trans phrase="Notifications are only sent once per entry.">"
         show_hint="1">
 
         <div>
             <input type="checkbox" name="nw_entry_created_auto" id="nw_entry_created_auto" value="1" <mt:if name="nw_entry_created_auto_1">checked="checked"</mt:if> />
-            <label for="nw_entry_created_auto"><__trans phrase="Send a notification automatically when a new entry is created."></label>
+            <label for="nw_entry_created_auto"><__trans phrase="Send a notification when a new entry is created."></label>
         </div>
         <div>
             <input type="checkbox" name="nw_entry_auto" id="nw_entry_auto" value="1" <mt:if name="nw_entry_auto_1">checked="checked"</mt:if> />
-            <label for="nw_entry_auto"><__trans phrase="Send a notification automatically when a new entry is published."></label>
+            <label for="nw_entry_auto"><__trans phrase="Send a notification when an entry is published or scheduled to be published."></label>
         </div>
     </mtapp:setting>
 

--- a/plugins/NotifyWho/tmpl/blog_config.tmpl
+++ b/plugins/NotifyWho/tmpl/blog_config.tmpl
@@ -61,6 +61,10 @@
         show_hint="1">
 
         <div>
+            <input type="checkbox" name="nw_entry_force" id="nw_entry_force" value="1" <mt:if name="nw_entry_force">checked="checked"</mt:if> />
+            <label for="nw_entry_force"><__trans phrase="Disallow users from turning off notifications for an entry."></label>
+        </div>
+        <div>
             <input type="checkbox" name="nw_entry_created_auto" id="nw_entry_created_auto" value="1" <mt:if name="nw_entry_created_auto_1">checked="checked"</mt:if> />
             <label for="nw_entry_created_auto"><__trans phrase="Send a notification when a new entry is created."></label>
         </div>

--- a/plugins/NotifyWho/tmpl/blog_config.tmpl
+++ b/plugins/NotifyWho/tmpl/blog_config.tmpl
@@ -20,6 +20,11 @@
         hint="<__trans phrase="Note: Enter email addresses on separate lines or separated by commas.">">
 
         <p>
+            <input type="checkbox" name="nw_entry_author" id="nw_entry_author" value="1" <mt:if name="nw_entry_author">checked="checked"</mt:if> />
+            <label for="nw_entry_author">Author<!-- (Add to “other e-mail addresses” list.) --></label>
+        </p>
+
+        <p>
             <input type="checkbox" name="nw_entry_list" id="nw_entry_list" value="1" <mt:if name="nw_entry_list">checked="checked"</mt:if> />
             <label for="nw_entry_list">Notification list subscribers, and/or</label>
         </p>
@@ -51,7 +56,7 @@
         <label for="nw_entry_text_excerpt"><__trans phrase="Excerpt"></label>
 
         <input type="radio" name="nw_entry_text" id="nw_entry_text_full" value="full" <mt:if name="nw_entry_text_full">checked="checked"</mt:if> />
-        <label for="nw_entry_text_full"><__trans phrase="Full"></label>       
+        <label for="nw_entry_text_full"><__trans phrase="Full"></label>
     </mtapp:setting>
 
     <mtapp:setting
@@ -82,7 +87,7 @@
     <h3><__trans phrase="Feedback notifications"></h3>
 
     <p><__trans phrase="These settings control the comment/TrackBack notification recipients if notifications are enabled.  Separate multiple recipients with commas and/or spaces."></p>
-    
+
     <mtapp:setting
         id="fback_recipients"
         label="<__trans phrase="Notification recipients">"
@@ -196,7 +201,7 @@
         <p style="margin-left: 20px;"><MT_TRANS phrase="When enabled, the option below will use the settings above to automatically send out entry notifications.  Notifications can always be sent manually regardless of this setting."></p>
 
         <div class="label">
-            <label><MT_TRANS phrase="Automatic">:</label> 
+            <label><MT_TRANS phrase="Automatic">:</label>
         </div>
 
         <div class="field">


### PR DESCRIPTION
The contained commits:
- Restore notification in MT5+ upon creating a draft. In MT4, the `cms_post_save.entry` callback returned nothing for the original object, whereas MT5+ returns a simple object.
- Notify upon setting draft entry to scheduled, or upon creating a scheduled entry if the “on create” setting is disabled.
- Notify upon publishing through Edit Entry screen an entry previously created as a draft. The hidden field associated with the notification toggle must be present to trigger the notification, but it was being omitted from Edit Entry if the entry was not new.
- Fix the “on create” and “on publish” settings to work sanely and be clearer. Previously both boxes had to be checked for any notifications to be sent.
- Notifications are now sent when draft entries are published via the Manage Entries screen or published or scheduled via Batch Edit entries function. The separate callback `cms_post_bulk_save.entries` is used for those functions, hence they were not picked up with `cms_post_save.entry`. Also, code was requiring a hidden form field on the Edit Entries screen, which does not apply to the bulk update methods.
- Add setting to prevent users from being able to disable notifications on the Edit Entry screen. This allows the plugin to function better in a work flow that requires an audit trail.
- Bump to 2.1.0, minor readme adjustments.
